### PR TITLE
Fix config.go and make the `template-website` runnable

### DIFF
--- a/cmd/qor5/website-template/admin/config.go
+++ b/cmd/qor5/website-template/admin/config.go
@@ -87,24 +87,25 @@ func newPB() Config {
 
 	utils.Configure(b)
 	media_view.Configure(b, db)
+	ab := activity.New(b, db).SetCreatorContextKey(login.UserKey)
+	l10nBuilder := l10n.New()
+	
 	pageBuilder := example.ConfigPageBuilder(db, "/admin/page_builder", ``, b.I18n())
-	pm := pageBuilder.Configure(b, db)
+	pm := pageBuilder.Configure(b, db, l10nBuilder, ab)
 	tm := pageBuilder.ConfigTemplate(b, db)
 	cm := pageBuilder.ConfigCategory(b, db)
-
-	ab := activity.New(b, db).SetCreatorContextKey(login.UserKey)
+	
 	ab.RegisterModels(pm, tm, cm)
 
 	storage := filesystem.New(PublishDir)
 	publisher := publish.New(db, storage).WithPageBuilder(pageBuilder)
 	publish_view.Configure(b, db, ab, publisher, pm)
 
-	l10nBuilder := l10n.New()
 	l10nBuilder.
-		RegisterLocales(countries.International, "International", "International").
-		RegisterLocales(countries.China, "China", "China").
-		GetSupportLocalesFromRequestFunc(func(R *http.Request) []countries.CountryCode {
-			return l10nBuilder.GetSupportLocales()[:]
+		RegisterLocales(countries.International.String(), "International", "International").
+		RegisterLocales(countries.China.String(), "China", "China").
+		GetSupportLocaleCodesFromRequestFunc(func(R *http.Request) []string {
+			return l10nBuilder.GetSupportLocaleCodes()[:]
 		})
 	l10n_view.Configure(b, db, l10nBuilder, ab, pm)
 


### PR DESCRIPTION
## What is happening?

1. Follow the [quick start](https://docs.qor5.com/getting-started/one-minute-quick-start.html) guide
2. Run command `qor5`
3. Select `template-website`
4. `qor5` generates the new `myadmin` directory with sampled codes
5. Run command `docker-compose up && source dev_env && go run main.go` to start the example
6.  [ISSUE here]  It will throw errors from `admin/config.go`

## What is expected?

Step 6 boots up the accessible website at
- CMS Served at http://localhost:9000/admin
- Publish Served at http://localhost:9001