### PR TITLE
fix mux_admin assets handle

### DIFF
--- a/docsrc/examples/mux_admin/mux.go
+++ b/docsrc/examples/mux_admin/mux.go
@@ -1,6 +1,8 @@
 package mux_admin
 
 import (
+	"net/http"
+
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/qor5/admin/v3/presets"
 	"github.com/qor5/docs/v3/docsrc"
@@ -9,7 +11,6 @@ import (
 	"github.com/qor5/docs/v3/docsrc/examples/mux_presets"
 	"github.com/qor5/docs/v3/docsrc/examples/mux_web_vuetify"
 	"github.com/theplant/docgo"
-	"net/http"
 )
 
 func Mux(mux *http.ServeMux, prefix string) http.Handler {
@@ -34,7 +35,7 @@ func Mux(mux *http.ServeMux, prefix string) http.Handler {
 }
 
 func SamplesHandler(prefix string) http.Handler {
-	mux := http.NewServeMux()
+	mux := &mux_web_vuetify.IndexMux{Mux: http.NewServeMux()}
 	mux_web_vuetify.SamplesHandler(mux, prefix)
 	mux_presets.SamplesHandler(mux, prefix)
 	addGA := mux_web_vuetify.AddGA
@@ -42,34 +43,34 @@ func SamplesHandler(prefix string) http.Handler {
 	c23 := presets.New().AssetFunc(addGA)
 	examples_admin.WorkerExampleMock(c23)
 	mux.Handle(
-		examples_admin.WorkerExamplePath+"/",
+		examples_admin.WorkerExamplePath,
 		c23,
 	)
 
 	c24 := presets.New().AssetFunc(addGA)
 	examples_admin.ActionWorkerExampleMock(c24)
 	mux.Handle(
-		examples_admin.ActionWorkerExamplePath+"/",
+		examples_admin.ActionWorkerExamplePath,
 		c24,
 	)
 
 	c27 := presets.New().AssetFunc(addGA)
 	examples_admin.InternationalizationExample(c27)
 	mux.Handle(
-		examples_admin.InternationalizationExamplePath+"/",
+		examples_admin.InternationalizationExamplePath,
 		c27)
 	c28 := presets.New().AssetFunc(addGA)
 	examples_admin.LocalizationExampleMock(c28)
 	mux.Handle(
-		examples_admin.LocalizationExamplePath+"/",
+		examples_admin.LocalizationExamplePath,
 		c28,
 	)
 
 	c29 := presets.New().AssetFunc(addGA)
 	examples_admin.PublishExample(c29)
 	mux.Handle(
-		examples_admin.PublishExamplePath+"/",
+		examples_admin.PublishExamplePath,
 		c29)
 
-	return mux
+	return mux.Mux
 }


### PR DESCRIPTION
各种 SamplesHandler 里的 mux.Handle 没有额外给到 / 后缀，直接使用会导致 vue.js 等资源文件无法加载，所以应使用 `mux_web_vuetify.IndexMux` 包裹，其内部对此有补充处理。
他处对 SamplesHandler 的调用均有包裹，`mux_admin.SamplesHandler` 里有缺失，导致 server/main.go 启动后，demo 跳转后是空白页。